### PR TITLE
Make mime types work in artifact, needs an lstrip(?.), updated tests

### DIFF
--- a/lib/artifact/endpoint.ex
+++ b/lib/artifact/endpoint.ex
@@ -28,6 +28,7 @@ defmodule Artifact.Endpoint do
         name
         |> Path.extname
         |> String.downcase
+        |> String.lstrip(?.)
         |> Plug.MIME.type
       end
 
@@ -49,7 +50,6 @@ defmodule Artifact.Endpoint do
       end
       defp asset_resp(data, name, conn) do
         type = content_type(name)
-
         conn
         |> put_resp_content_type(type)
         |> send_resp(200, data)

--- a/test/artifact/endpoint_test.exs
+++ b/test/artifact/endpoint_test.exs
@@ -15,6 +15,7 @@ defmodule Artifact.EndpointTest do
     assert resp.state == :sent
     assert resp.status == 200
     assert resp.resp_body == "test"
+    assert get_resp_header(resp, "content-type") == ["text/plain; charset=utf-8"]
   end
 
   test "returns processed file for requested format" do
@@ -25,6 +26,7 @@ defmodule Artifact.EndpointTest do
     assert resp.state == :sent
     assert resp.status == 200
     assert resp.resp_body == "TSET"
+    assert get_resp_header(resp, "content-type") == ["text/plain; charset=utf-8"]
   end
 
   test "returns 404 for missing format" do
@@ -35,6 +37,7 @@ defmodule Artifact.EndpointTest do
     assert resp.state == :sent
     assert resp.status == 404
   end
+
 
   def exec([], data), do: data
   def exec("upcase", data), do: String.upcase(data)


### PR DESCRIPTION
Simple fix to return the correct mime type and test for it.

Mime type is currently based upon filename, maybe should be detected eventually.
